### PR TITLE
add /metainfo endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are several routes to interact with torrents:
 -	`GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
 -	`GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
 -	`GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
+-	`GET /torrent?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
 -	`/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
 -	`GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
 -	`POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are several routes to interact with torrents:
 -	`GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
 -	`GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
 -	`GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
--	`GET /torrent?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
 -	`/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
 -	`GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
 -	`POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
+-	`GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -27,7 +27,6 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	getHandler(r).TC.WriteStatus(w)
 }
 
-
 func findTorrent(w http.ResponseWriter, r *http.Request) *torrent.Torrent {
 	t := torrentForRequest(r)
 	if nowait, err := strconv.ParseBool(r.URL.Query().Get("nowait")); err == nil && nowait {
@@ -60,7 +59,7 @@ func infoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(mi.InfoBytes)
 }
 
-func torrentHandler(w http.ResponseWriter, r *http.Request) {
+func metainfoGetHandler(w http.ResponseWriter, r *http.Request) {
 	t := findTorrent(w, r)
 	if t == nil {
 		return
@@ -118,7 +117,7 @@ func fileStateHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(f.State())
 }
 
-func metainfoHandler(w http.ResponseWriter, r *http.Request) {
+func metainfoPostHandler(w http.ResponseWriter, r *http.Request) {
 	var mi metainfo.MetaInfo
 	err := bencode.NewDecoder(r.Body).Decode(&mi)
 	if err != nil {

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -65,6 +65,7 @@ func torrentHandler(w http.ResponseWriter, r *http.Request) {
 	if t == nil {
 		return
 	}
+	w.Header().Add("Content-Type", "application/x-bittorrent")
 	t.Metainfo().Write(w)
 }
 

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -117,6 +117,14 @@ func fileStateHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(f.State())
 }
 
+func metainfoHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == "POST" {
+		metainfoPostHandler(w, r)
+		return
+	}
+	metainfoGetHandler(w, r)
+}
+
 func metainfoPostHandler(w http.ResponseWriter, r *http.Request) {
 	var mi metainfo.MetaInfo
 	err := bencode.NewDecoder(r.Body).Decode(&mi)

--- a/confluence/mux.go
+++ b/confluence/mux.go
@@ -13,11 +13,10 @@ func init() {
 	mux.Handle("/data", alice.New(withTorrentContext).ThenFunc(dataHandler))
 	mux.HandleFunc("/status", statusHandler)
 	mux.Handle("/info", alice.New(withTorrentContext).ThenFunc(infoHandler))
-	mux.Handle("/metainfo", alice.New(withTorrentContext).ThenFunc(metainfoGetHandler))
 	mux.Handle("/events", alice.New(withTorrentContext).ThenFunc(eventHandler))
 	mux.Handle("/fileState", alice.New(
 		withTorrentContext,
 		httptoo.GzipHandler,
 	).ThenFunc(fileStateHandler))
-	mux.Handle("/metainfo", alice.New(withTorrentContext).ThenFunc(metainfoPostHandler))
+	mux.Handle("/metainfo", alice.New(withTorrentContext).ThenFunc(metainfoHandler))
 }

--- a/confluence/mux.go
+++ b/confluence/mux.go
@@ -13,11 +13,11 @@ func init() {
 	mux.Handle("/data", alice.New(withTorrentContext).ThenFunc(dataHandler))
 	mux.HandleFunc("/status", statusHandler)
 	mux.Handle("/info", alice.New(withTorrentContext).ThenFunc(infoHandler))
-	mux.Handle("/torrent", alice.New(withTorrentContext).ThenFunc(torrentHandler))
+	mux.Handle("/metainfo", alice.New(withTorrentContext).ThenFunc(metainfoGetHandler))
 	mux.Handle("/events", alice.New(withTorrentContext).ThenFunc(eventHandler))
 	mux.Handle("/fileState", alice.New(
 		withTorrentContext,
 		httptoo.GzipHandler,
 	).ThenFunc(fileStateHandler))
-	mux.Handle("/metainfo", alice.New(withTorrentContext).ThenFunc(metainfoHandler))
+	mux.Handle("/metainfo", alice.New(withTorrentContext).ThenFunc(metainfoPostHandler))
 }


### PR DESCRIPTION
Some apps need the standard torrent file not to implement new parsers. This endpoint will provide the torrent file.