### PR TITLE
Improve torrent cache

### DIFF
--- a/confluence/handler.go
+++ b/confluence/handler.go
@@ -3,6 +3,7 @@ package confluence
 import (
 	"context"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/anacrolix/torrent"
@@ -12,9 +13,14 @@ type Handler struct {
 	TC             *torrent.Client
 	TorrentGrace   time.Duration
 	OnTorrentGrace func(t *torrent.Torrent)
+	CacheDir       string
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(context.WithValue(r.Context(), handlerContextKey, h))
 	mux.ServeHTTP(w, r)
+}
+
+func (h Handler) cachePath(s string) string {
+	return filepath.Join(h.CacheDir, "torrents", string(s[0]), string(s[1]), string(s[2]))
 }

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -135,5 +135,5 @@ func metainfoPostHandler(w http.ResponseWriter, r *http.Request) {
 	t := torrentForRequest(r)
 	t.AddTrackers(mi.UpvertedAnnounceList())
 	t.SetInfoBytes(mi.InfoBytes)
-	saveTorrentFile(t)
+	saveTorrentFile(t, r)
 }

--- a/confluence/misc.go
+++ b/confluence/misc.go
@@ -22,10 +22,12 @@ func torrentFileByPath(t *torrent.Torrent, path_ string) *torrent.File {
 	return nil
 }
 
-func saveTorrentFile(t *torrent.Torrent) (err error) {
-	path_ := filepath.Join("torrents", t.InfoHash().HexString()+".torrent")
-	os.MkdirAll(filepath.Dir(path_), 0750)
-	f, err := os.OpenFile(path_, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
+func saveTorrentFile(t *torrent.Torrent, r *http.Request) (err error) {
+	h := getHandler(r)
+	dir := h.cachePath(t.InfoHash().HexString())
+	p := filepath.Join(dir, t.InfoHash().HexString()+".torrent")
+	os.MkdirAll(dir, 0750)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Currently all torrents are saved in one directory in the binary root. This PR will use the FileDir flag to move that directory to the user input path and separate the files using the first 3 chars of each hash.