### PR TITLE
Return JSON from /info based on Accept header

### DIFF
--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -51,7 +51,43 @@ func infoHandler(w http.ResponseWriter, r *request) {
 		return
 	}
 	mi := r.torrent.Metainfo()
-	w.Write(mi.InfoBytes)
+	switch r.Header.Get("Accept") {
+	case "application/json":
+		nodes := make([]string, len(mi.Nodes))
+		for _, n := range mi.Nodes {
+			nodes = append(nodes, string(n))
+		}
+		announceList := [][]string{}
+		if mi.AnnounceList != nil {
+			announceList = mi.AnnounceList
+		}
+		urlList := []string{}
+		if mi.UrlList != nil {
+			urlList = mi.UrlList
+		}
+		enc := json.NewEncoder(w)
+		enc.Encode(struct {
+			Announce     string     `json:"announce"`
+			AnnounceList [][]string `json:"announceList"`
+			Nodes        []string   `json:"nodes"`
+			CreationDate int64      `json:"creationDate"`
+			Comment      string     `json:"comment,omitempty"`
+			CreatedBy    string     `json:"createdBy"`
+			Encoding     string     `json:"encoding"`
+			UrlList      []string   `json:"urlList"`
+		}{
+			Announce:     mi.Announce,
+			AnnounceList: announceList,
+			Nodes:        nodes,
+			CreationDate: mi.CreationDate,
+			Comment:      mi.Comment,
+			CreatedBy:    mi.CreatedBy,
+			Encoding:     mi.Encoding,
+			UrlList:      urlList,
+		})
+	default:
+		w.Write(mi.InfoBytes)
+	}
 }
 
 func (h *Handler) metainfoGetHandler(w http.ResponseWriter, r *request) {

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -51,43 +51,7 @@ func infoHandler(w http.ResponseWriter, r *request) {
 		return
 	}
 	mi := r.torrent.Metainfo()
-	switch r.Header.Get("Accept") {
-	case "application/json":
-		nodes := make([]string, len(mi.Nodes))
-		for _, n := range mi.Nodes {
-			nodes = append(nodes, string(n))
-		}
-		enc := json.NewEncoder(w)
-		enc.Encode(struct {
-			Announce     string     `json:",omitempty"`
-			AnnounceList [][]string `json:",omitempty"`
-			Nodes        []string   `json:",omitempty"`
-			CreationDate int64      `json:",omitempty"`
-			Comment      string     `json:",omitempty"`
-			CreatedBy    string     `json:",omitempty"`
-			Encoding     string     `json:",omitempty"`
-			UrlList      []string   `json:",omitempty"`
-		}{
-			Announce:     mi.Announce,
-			AnnounceList: mi.AnnounceList,
-			Nodes:        nodes,
-			CreationDate: mi.CreationDate,
-			Comment:      mi.Comment,
-			CreatedBy:    mi.CreatedBy,
-			Encoding:     mi.Encoding,
-			UrlList:      mi.UrlList,
-		})
-	default:
-		w.Write(mi.InfoBytes)
-	}
-}
-
-func (h *Handler) metainfoGetHandler(w http.ResponseWriter, r *request) {
-	if !waitForTorrentInfo(w, r) {
-		return
-	}
-	w.Header().Add("Content-Type", "application/x-bittorrent")
-	r.torrent.Metainfo().Write(w)
+	w.Write(mi.InfoBytes)
 }
 
 func eventHandler(w http.ResponseWriter, r *request) {
@@ -148,7 +112,45 @@ func (h *Handler) metainfoHandler(w http.ResponseWriter, r *request) {
 		h.metainfoPostHandler(w, r)
 		return
 	}
-	h.metainfoGetHandler(w, r)
+
+	if !waitForTorrentInfo(w, r) {
+		return
+	}
+	mi := r.torrent.Metainfo()
+
+	switch r.Header.Get("Accept") {
+	case "application/json":
+		w.Header().Add("Content-Type", "application/json")
+		nodes := make([]string, len(mi.Nodes))
+		for _, n := range mi.Nodes {
+			nodes = append(nodes, string(n))
+		}
+		enc := json.NewEncoder(w)
+		enc.Encode(struct {
+			Info         []byte     `json:"info,omitempty"`
+			Announce     string     `json:"announce,omitempty"`
+			AnnounceList [][]string `json:"announceList,omitempty"`
+			Nodes        []string   `json:"nodes,omitempty"`
+			CreationDate int64      `json:"creationDate,omitempty"`
+			Comment      string     `json:"comment,omitempty"`
+			CreatedBy    string     `json:"createdBy,omitempty"`
+			Encoding     string     `json:"encoding,omitempty"`
+			UrlList      []string   `json:"urlList,omitempty"`
+		}{
+			Info:         mi.InfoBytes,
+			Announce:     mi.Announce,
+			AnnounceList: mi.AnnounceList,
+			Nodes:        nodes,
+			CreationDate: mi.CreationDate,
+			Comment:      mi.Comment,
+			CreatedBy:    mi.CreatedBy,
+			Encoding:     mi.Encoding,
+			UrlList:      mi.UrlList,
+		})
+	default:
+		w.Header().Add("Content-Type", "application/x-bittorrent")
+		mi.Write(w)
+	}
 }
 
 func (h *Handler) metainfoPostHandler(w http.ResponseWriter, r *request) {

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -57,33 +57,25 @@ func infoHandler(w http.ResponseWriter, r *request) {
 		for _, n := range mi.Nodes {
 			nodes = append(nodes, string(n))
 		}
-		announceList := [][]string{}
-		if mi.AnnounceList != nil {
-			announceList = mi.AnnounceList
-		}
-		urlList := []string{}
-		if mi.UrlList != nil {
-			urlList = mi.UrlList
-		}
 		enc := json.NewEncoder(w)
 		enc.Encode(struct {
-			Announce     string
-			AnnounceList [][]string
-			Nodes        []string
-			CreationDate int64
-			Comment      string
-			CreatedBy    string
-			Encoding     string
-			UrlList      []string
+			Announce     string     `json:",omitempty"`
+			AnnounceList [][]string `json:",omitempty"`
+			Nodes        []string   `json:",omitempty"`
+			CreationDate int64      `json:",omitempty"`
+			Comment      string     `json:",omitempty"`
+			CreatedBy    string     `json:",omitempty"`
+			Encoding     string     `json:",omitempty"`
+			UrlList      []string   `json:",omitempty"`
 		}{
 			Announce:     mi.Announce,
-			AnnounceList: announceList,
+			AnnounceList: mi.AnnounceList,
 			Nodes:        nodes,
 			CreationDate: mi.CreationDate,
 			Comment:      mi.Comment,
 			CreatedBy:    mi.CreatedBy,
 			Encoding:     mi.Encoding,
-			UrlList:      urlList,
+			UrlList:      mi.UrlList,
 		})
 	default:
 		w.Write(mi.InfoBytes)

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -67,14 +67,14 @@ func infoHandler(w http.ResponseWriter, r *request) {
 		}
 		enc := json.NewEncoder(w)
 		enc.Encode(struct {
-			Announce     string     `json:"announce"`
-			AnnounceList [][]string `json:"announceList"`
-			Nodes        []string   `json:"nodes"`
-			CreationDate int64      `json:"creationDate"`
-			Comment      string     `json:"comment,omitempty"`
-			CreatedBy    string     `json:"createdBy"`
-			Encoding     string     `json:"encoding"`
-			UrlList      []string   `json:"urlList"`
+			Announce     string
+			AnnounceList [][]string
+			Nodes        []string
+			CreationDate int64
+			Comment      string
+			CreatedBy    string
+			Encoding     string
+			UrlList      []string
 		}{
 			Announce:     mi.Announce,
 			AnnounceList: announceList,


### PR DESCRIPTION
Implements https://github.com/anacrolix/confluence/issues/18

```
$ curl -H 'accept: application/json' "http://127.0.0.1:8080/info?ih=b8aefdbc4d06b2f69829f8a091a01d60e3a7886c"
{"Announce":"","AnnounceList":[],"Nodes":[],"CreationDate":1586250574,"Comment":"dynamic metainfo from client","CreatedBy":"go.torrent","Encoding":"","UrlList":[]}```