### PR TITLE
Add Dockerfile for development.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang
+
+WORKDIR /go/src/confluence/
+
+COPY ./go.mod .
+COPY ./go.sum .
+RUN go mod download -x
+
+COPY . .
+RUN go install -v
+
+ENTRYPOINT [ "confluence" ]
+CMD [ "-h" ]

--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ There are several routes to interact with torrents:
 -	`GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
 -	`POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
 -	`GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
+
+Wherever a `?ih=<infohash>` query parameter is expected, it can also be substituted by a `?magnet=<magnet URI>` parameter instead.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,25 @@ $ godo github.com/anacrolix/confluence -h
 Usage:
   confluence [OPTIONS...]
 Options:
-  -addr            (string)          HTTP listen address (Default: localhost:8080)
-  -cacheCapacity   (tagflag.Bytes)   Data cache capacity (Default: 11 GB)
-  -debugOnMain     (bool)            Expose default serve mux /debug/ endpoints over http
-  -dhtPublicIP     (net.IP)          DHT secure IP
-  -fileDir         (string)          File-based storage directory, overrides piece storage
-  -seed            (bool)            Seed data
-  -torrentGrace    (time.Duration)   How long to wait to drop a torrent after its last request (Default: 1m0s)
+  -addr                    (string)          HTTP listen address (Default: localhost:8080)
+  -cacheCapacity           (tagflag.Bytes)   Data cache capacity (Default: 11 GB)
+  -collectCamouflageData   (bool)
+  -debugOnMain             (bool)            Expose default serve mux /debug/ endpoints over http
+  -dht                     (bool)            Default: true
+  -disableTrackers         (bool)            Disables all trackers
+  -fileDir                 (string)          File-based storage directory, overrides piece storage
+  -implicitTracker         ([]string)        Trackers to be used for all torrents
+  -overrideTrackers        (bool)            Only use implied trackers
+  -pex                     (bool)            Default: true
+  -publicIp4               (net.IP)          Public IPv4 address
+  -publicIp6               (net.IP)          Public IPv6 address
+  -seed                    (bool)            Seed data
+  -sqliteStorage           (*string)
+  -tcpPeers                (bool)            Allow TCP peers (Default: true)
+  -torrentGrace            (time.Duration)   How long to wait to drop a torrent after its last request (Default: 1m0s)
+  -uPnPPortForwarding      (bool)            Port forward via UPnP
+  -unlimitedCache          (bool)            Don't limit cache capacity
+  -utpPeers                (bool)            Allow uTP peers (Default: true)
 ```
 
 Confluence will announce itself to DHT, and wait for HTTP activity. Torrents are added to the client as needed. Without an active request on a torrent, it is kicked from the client after the torrent grace period. Its data however may remain in the cache for future uses of that torrent.


### PR DESCRIPTION
I wanted to try the software (which you suggested in anacrolix/torrent#386) using Docker, since I don't have/want to install Golang packages on my PC. Thus, if I have to tinker with code, I will also be able to.

It's focused on local development:
* Allows development without installing Golang toolchain, AFAICT.
* Decreased repeated build time due to splitting mod downloading from compilation, thus benefitting from Docker image layer caching speedup.
* No image size optimizations (eg. not using `golang:alpine` as base image)﻿. If a more slim, production-optimized artifact is desired, this image can be used as base image.
* Unopinionated (no forced command line switches). Just a sensible `-h` by default, if none given.
* Somewhat verbose when building to keep an eye on build progress.

For convenience, I've set up a Docker Hub Automated Build at https://hub.docker.com/r/pataquets/confluence-src/ which I'll be using to deploy and test on other machines.
I'll be crafting a Docker Compose test manifest soon, which I can PR, if interested.
I hope you'll find it useful.
