### PR TITLE
Ensure meta info exists when adding trackers

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func mainErr() error {
 			onTorrentGraceExtra(ih)
 		},
 		OnNewTorrent: func(t *torrent.Torrent, mi *metainfo.MetaInfo) {
-			if !flags.OverrideTrackers {
+			if !flags.OverrideTrackers && mi != nil {
 				t.AddTrackers(mi.UpvertedAnnounceList())
 			}
 			t.AddTrackers([][]string{flags.ImplicitTracker})


### PR DESCRIPTION
Meta info isn't necessarily set when a torrent that hasn't been seen before is added.