### PR TITLE
Add Docker push action on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          labels: |
+            anacrolix/confluence:${{ GITHUB_REF }}
+            anacrolix/confluence:latest


### PR DESCRIPTION
Add a GitHub Action to push to Docker Hub automatically each time each tagged release is published. Need to set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets in the repo for authentication.

Signed-off-by: Bora M. Alper <bora@boramalper.org>