### PR TITLE
Allow accessing data by paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,17 @@ Routes
 
 There are several routes to interact with torrents:
 
--	`GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>&filename=<file name of the data, optional>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
--	`GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
--	`GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
--	`/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
--	`GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
--	`POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
--	`GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
+- `GET /data/infohash/<infohash in hex>/<display path of file declared in torrent info>`
+
+  `GET /data/magnet/<URI-encoded magnet link>/<display path of file declared in torrent info>`
+
+  `GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>&filename=<file name of the data, optional>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
+- `GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
+- `GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
+- `/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
+- `GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
+- `POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
+- `GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
 
 Wherever a `?ih=<infohash>` query parameter is expected, it can also be substituted by a `?magnet=<magnet URI>` parameter instead.
 

--- a/README.md
+++ b/README.md
@@ -56,17 +56,15 @@ Routes
 
 There are several routes to interact with torrents:
 
-- `GET /data/infohash/<infohash in hex>/<display path of file declared in torrent info>`
+-	`GET /data/infohash/<infohash in hex>/<display path of file declared in torrent info>`
 
-  `GET /data/magnet/<URI-encoded magnet link>/<display path of file declared in torrent info>`
-
-  `GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>&filename=<file name of the data, optional>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
-- `GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
-- `GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
-- `/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
-- `GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
-- `POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
-- `GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
+ 	`GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>&filename=<file name of the data, optional>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
+-	`GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
+-	`GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
+-	`/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
+-	`GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
+-	`POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
+-	`GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
 
 Wherever a `?ih=<infohash>` query parameter is expected, it can also be substituted by a `?magnet=<magnet URI>` parameter instead.
 

--- a/confluence/handlers.go
+++ b/confluence/handlers.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 	"sync"
+	"strings"
 
 	"github.com/anacrolix/dht/v2/bep44"
 	"github.com/anacrolix/dht/v2/exts/getput"
@@ -26,15 +27,22 @@ func dataHandler(w http.ResponseWriter, r *request) {
 			"Content-Disposition", "filename="+strconv.Quote(q.Get("filename")),
 		)
 	}
-	if len(q["path"]) == 0 {
+	filepath := q.Get("path")
+	if filepath == "" {
+		parts := strings.SplitN(r.URL.Path, "/", 5)
+		if len(parts) == 5 {
+			filepath = parts[4]
+		}
+	}
+	if filepath == "" {
 		ServeTorrent(w, r.Request, t)
 	} else {
 		if !q.Has("filename") {
 			w.Header().Set(
-				"Content-Disposition", "filename="+strconv.Quote(path.Base(q.Get("path"))),
+				"Content-Disposition", "filename="+strconv.Quote(path.Base(filepath)),
 			)
 		}
-		ServeFile(w, r.Request, t, q.Get("path"))
+		ServeFile(w, r.Request, t, filepath)
 	}
 }
 

--- a/confluence/middlewares.go
+++ b/confluence/middlewares.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"time"
 	"strings"
-	"net/url"
 
 	"github.com/anacrolix/squirrel"
 	"github.com/anacrolix/torrent"
@@ -52,13 +51,6 @@ func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request))
 		ih, err, afterAdd := func() (ih metainfo.Hash, err error, afterAdd func(t *torrent.Torrent)) {
 			q := r.URL.Query()
 			ms := q.Get("magnet")
-			parts := strings.SplitN(r.URL.Path, "/", 5)
-			//   /<handler>/magnet|infohash/<magnet or infohash>/...
-			//[0] [1]      [2]             [3]                   [4]
-			if ms == "" && len(parts) >= 4 && parts[2] == "magnet" {
-				ms, err = url.PathUnescape(parts[3])
-			}
-
 			if ms != "" {
 				m, err := metainfo.ParseMagnetUri(ms)
 				if err != nil {
@@ -71,8 +63,13 @@ func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request))
 				}
 			}
 			ihhex := q.Get(infohashQueryKey)
-			if ihhex == "" && len(parts) >= 4 && parts[2] == "infohash" {
-				ihhex = parts[3]
+			if ihhex == "" {
+				parts := strings.SplitN(r.URL.Path, "/", 5)
+				//   /<handler>/infohash/<infohash>/...
+				//[0] [1]      [2]       [3]        [4]
+				if len(parts) >= 4 && parts[2] == "infohash" {
+					ihhex = parts[3]
+				}
 			}
 			if ihhex != "" {
 				err = ih.FromHexString(ihhex)

--- a/confluence/mux.go
+++ b/confluence/mux.go
@@ -9,17 +9,17 @@ import (
 func (h *Handler) initMux() {
 	h.initMuxOnce.Do(func() {
 		mux := &h.mux
-		mux.Handle("/data", h.withTorrentContext(dataHandler))
+		mux.Handle("/data/", h.withTorrentContext(dataHandler))
 		mux.HandleFunc("/status", h.statusHandler)
-		mux.Handle("/info", h.withTorrentContext(infoHandler))
-		mux.Handle("/events", h.withTorrentContext(eventHandler))
-		mux.Handle("/fileState", h.withTorrentContext(func(w http.ResponseWriter, r *request) {
+		mux.Handle("/info/", h.withTorrentContext(infoHandler))
+		mux.Handle("/events/", h.withTorrentContext(eventHandler))
+		mux.Handle("/fileState/", h.withTorrentContext(func(w http.ResponseWriter, r *request) {
 			httptoo.GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, hr *http.Request) {
 				r.Request = hr
 				fileStateHandler(w, r)
 			})).ServeHTTP(w, r.Request)
 		}))
-		mux.Handle("/metainfo", h.withTorrentContext(h.metainfoHandler))
+		mux.Handle("/metainfo/", h.withTorrentContext(h.metainfoHandler))
 		mux.HandleFunc("/bep44", h.handleBep44)
 	})
 }

--- a/confluence/mux.go
+++ b/confluence/mux.go
@@ -9,16 +9,20 @@ import (
 func (h *Handler) initMux() {
 	h.initMuxOnce.Do(func() {
 		mux := &h.mux
+		mux.Handle("/data", h.withTorrentContext(dataHandler))
 		mux.Handle("/data/", h.withTorrentContext(dataHandler))
 		mux.HandleFunc("/status", h.statusHandler)
+		mux.Handle("/info", h.withTorrentContext(infoHandler))
 		mux.Handle("/info/", h.withTorrentContext(infoHandler))
+		mux.Handle("/events", h.withTorrentContext(eventHandler))
 		mux.Handle("/events/", h.withTorrentContext(eventHandler))
-		mux.Handle("/fileState/", h.withTorrentContext(func(w http.ResponseWriter, r *request) {
+		mux.Handle("/fileState", h.withTorrentContext(func(w http.ResponseWriter, r *request) {
 			httptoo.GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, hr *http.Request) {
 				r.Request = hr
 				fileStateHandler(w, r)
 			})).ServeHTTP(w, r.Request)
 		}))
+		mux.Handle("/metainfo", h.withTorrentContext(h.metainfoHandler))
 		mux.Handle("/metainfo/", h.withTorrentContext(h.metainfoHandler))
 		mux.HandleFunc("/bep44", h.handleBep44)
 	})


### PR DESCRIPTION
#17
Rationale:
- HTTP clients can infer the filename by path (without even starting the download), so there is no need for `?filename=`
- Some files can refer to other files in the same directory. For example, the file is a playlist and media player now can seamlessly load other files it refers to using http.

This PR adds these endpoints:
`GET /data/infohash/<infohash in hex>/<display path of file declared in torrent info>`
`GET /data/magnet/<URI-encoded magnet link>/<display path of file declared in torrent info>`