### PR TITLE
Add path-based data handler route

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,18 @@ Routes
 
 There are several routes to interact with torrents:
 
--	`GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>&filename=<file name of the data, optional>`. Note that this handler supports HTTP range requests for bytes. Response will block until the data is available.
--	`GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
--	`GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
--	`/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
--	`GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
--	`POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
--	`GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
+- `GET /data?ih=<infohash in hex>&path=<display path of file declared in torrent info>&filename=<file name of the data, optional>`,
+  
+  or `GET /data/infohash/<infohash in hex>/<display path of file declared in torrent info>`: 
+  
+  Responds with file or whole-torrent data, depending on presence of file name argument. 
+  Note that this handler supports HTTP range requests for bytes. Response blocks until the data is available.
+- `GET /status`. This fetches the textual status info page per anacrolix/torrent.Client.WriteStatus. Very useful for debugging.
+- `GET /info?ih=<infohash in hex>`. This returns the info bytes for the matching torrent. It's useful if the caller needs to know about the torrent, such as what files it contains. It will block until the info is available. The response is the full bencoded info dictionary per [BEP 3](http://www.bittorrent.org/beps/bep_0003.html).
+- `/events?ih=<infohash in hex>`. This is a websocket that emits frames with [confluence.Event] encoded as JSON for the torrent. The PieceChanged field for instance is set if the given piece changed [state](https://godoc.org/github.com/anacrolix/torrent#PieceState) within the torrent.
+- `GET /fileState?ih=<infohash in hex>&path=<display path of file declared in torrent info>`. Returns [file state](https://godoc.org/github.com/anacrolix/torrent#File.State) encoded as JSON.
+- `POST /metainfo?ih=<infohash in hex>`. The request body is a bencoded metainfo, as typically appears in a `.torrent` file. The trackers and info bytes are applied to the torrent matching the info hash provided in the query. No fields in the metainfo are mandatory.
+- `GET /metainfo?ih=<infohash in hex>`. returns a .torrent file containing the hash info.
 
 Wherever a `?ih=<infohash>` query parameter is expected, it can also be substituted by a `?magnet=<magnet URI>` parameter instead.
 

--- a/confluence/middlewares.go
+++ b/confluence/middlewares.go
@@ -110,7 +110,7 @@ func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request),
 	})
 }
 
-func (me *Handler) withTorrentContextFromPath(h func(http.ResponseWriter, *request)) http.Handler {
+func (me *Handler) withTorrentContextFromInfohashPath(h func(http.ResponseWriter, *request)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		me.withTorrentContext(h, func() (ih metainfo.Hash, err error, afterAdd func(t *torrent.Torrent)) {
 			p := r.URL.Path

--- a/confluence/middlewares.go
+++ b/confluence/middlewares.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/anacrolix/squirrel"
@@ -45,9 +46,9 @@ type request struct {
 	*http.Request
 }
 
-func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request)) http.Handler {
+func (me *Handler) withTorrentContextFromQuery(h func(w http.ResponseWriter, r *request)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ih, err, afterAdd := func() (ih metainfo.Hash, err error, afterAdd func(t *torrent.Torrent)) {
+		me.withTorrentContext(h, func() (ih metainfo.Hash, err error, afterAdd func(t *torrent.Torrent)) {
 			q := r.URL.Query()
 			ms := q.Get("magnet")
 			if ms != "" {
@@ -67,7 +68,18 @@ func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request))
 			}
 			err = fmt.Errorf("expected nonempty query parameter %q or %q", magnetQueryKey, infohashQueryKey)
 			return
-		}()
+		}).ServeHTTP(w, r)
+	})
+}
+
+// Determines intended torrent for a request, and any extra behaviour that can be implied when
+// adding it to the torrent Client.
+type torrentContextGetter func() (ih metainfo.Hash, err error, afterAdd func(t *torrent.Torrent))
+
+// Returns a middleware that calls in to a handler that expects a Torrent.
+func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request), getTorrent torrentContextGetter) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ih, err, afterAdd := getTorrent()
 		if err != nil {
 			http.Error(w, fmt.Errorf("error determining requested infohash: %w", err).Error(), http.StatusBadRequest)
 			return
@@ -95,6 +107,27 @@ func (me *Handler) withTorrentContext(h func(w http.ResponseWriter, r *request))
 		}
 		me.saveTorrentFile(t)
 		h(w, &request{t, me, r})
+	})
+}
+
+func (me *Handler) withTorrentContextFromPath(h func(http.ResponseWriter, *request)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		me.withTorrentContext(h, func() (ih metainfo.Hash, err error, afterAdd func(t *torrent.Torrent)) {
+			p := r.URL.Path
+			start := 1 // path should always start with /
+			end := strings.IndexByte(p[start:], '/')
+			if end == -1 {
+				// There's no next path segment, that might be okay.
+				end = len(p)
+			} else {
+				end += start
+			}
+			err = ih.FromHexString(p[start:end])
+			// Note that we're modifying our caller's Request, and not modifying RawPath, both of
+			// which could be dangerous.
+			r.URL.Path = p[end:]
+			return
+		}).ServeHTTP(w, r)
 	})
 }
 

--- a/confluence/mux.go
+++ b/confluence/mux.go
@@ -9,17 +9,18 @@ import (
 func (h *Handler) initMux() {
 	h.initMuxOnce.Do(func() {
 		mux := &h.mux
-		mux.Handle("/data", h.withTorrentContext(dataHandler))
+		mux.Handle("/data", h.withTorrentContextFromQuery(dataQueryHandler))
+		mux.Handle("/data/", http.StripPrefix("/data", h.withTorrentContextFromPath(dataPathHandler)))
 		mux.HandleFunc("/status", h.statusHandler)
-		mux.Handle("/info", h.withTorrentContext(infoHandler))
-		mux.Handle("/events", h.withTorrentContext(eventHandler))
-		mux.Handle("/fileState", h.withTorrentContext(func(w http.ResponseWriter, r *request) {
+		mux.Handle("/info", h.withTorrentContextFromQuery(infoHandler))
+		mux.Handle("/events", h.withTorrentContextFromQuery(eventHandler))
+		mux.Handle("/fileState", h.withTorrentContextFromQuery(func(w http.ResponseWriter, r *request) {
 			httptoo.GzipHandler(http.HandlerFunc(func(w http.ResponseWriter, hr *http.Request) {
 				r.Request = hr
 				fileStateHandler(w, r)
 			})).ServeHTTP(w, r.Request)
 		}))
-		mux.Handle("/metainfo", h.withTorrentContext(h.metainfoHandler))
+		mux.Handle("/metainfo", h.withTorrentContextFromQuery(h.metainfoHandler))
 		mux.HandleFunc("/bep44", h.handleBep44)
 	})
 }

--- a/confluence/mux.go
+++ b/confluence/mux.go
@@ -10,7 +10,9 @@ func (h *Handler) initMux() {
 	h.initMuxOnce.Do(func() {
 		mux := &h.mux
 		mux.Handle("/data", h.withTorrentContextFromQuery(dataQueryHandler))
-		mux.Handle("/data/", http.StripPrefix("/data", h.withTorrentContextFromPath(dataPathHandler)))
+		mux.Handle("/data/infohash/", http.StripPrefix(
+			"/data/infohash",
+			h.withTorrentContextFromInfohashPath(dataPathHandler)))
 		mux.HandleFunc("/status", h.statusHandler)
 		mux.Handle("/info", h.withTorrentContextFromQuery(infoHandler))
 		mux.Handle("/events", h.withTorrentContextFromQuery(eventHandler))


### PR DESCRIPTION
Improve data handler description in README and let GoLand clobber markdownfmt's formatting, which doesn't seem to handle multiple paragraphs in a single dot point.

Improve abstractions around torrent context, common query keys and content-disposition handling.

Fixes https://github.com/anacrolix/confluence/issues/17.

Alternative to https://github.com/anacrolix/confluence/pull/33.